### PR TITLE
Increased the default vm.kmem vfs.zfs params.

### DIFF
--- a/boot/loader.conf
+++ b/boot/loader.conf
@@ -36,9 +36,9 @@ opensolaris_load="YES"
 zfs_load="YES"
 
 # Tune arc for lower memory usage during LiveCD session
-vm.kmem_size="330M"
-vm.kmem_size_max="330M"
-vfs.zfs.arc_max="40M"
+vm.kmem_size="1024M"
+vm.kmem_size_max="1024M"
+vfs.zfs.arc_max="512M"
 vfs.zfs.vdev.cache.size="5M"
 
 # Disable host UUID


### PR DESCRIPTION
Increased the default vm.kmem parameters to eliminate the following error: 
Oct 28 23:26:51  kernel: ZFS WARNING: Recommended minimum kmem_size is 512MB; expect unstable behavior.
Oct 28 23:26:51  kernel:              Consider tuning vm.kmem_size and vm.kmem_size_max
Oct 28 23:26:51  kernel:              in /boot/loader.conf.

vfs.zfs.arc_max parameter to what is currently used for new pool/ramdisk method when installing GhostBSD.