### PR TITLE
Add /boot/entropy file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -219,6 +219,8 @@ extra_config()
   mv ${release}/usr/local/etc/devd-openrc/automount_devd.conf ${release}/usr/local/etc/devd-openrc/automount_devd.conf.skip
   # Mkdir for linux compat to ensure /etc/fstab can mount when booting LiveCD
   chroot ${release} mkdir -p /compat/linux/dev/shm
+  # Add /boot/entropy file
+  chroot ${release} touch /boot/entropy
 }
 
 xorg()


### PR DESCRIPTION
To eliminate the following error message, a /boot/entropy file needs to be create.

"Oct 29 09:02:19  kernel: arc4random: no preloaded entropy cache"

Note: Next pull request, will change /boot/loader entry to: entropy_cache_load="YES" to correct error.