### PR TITLE
Changed entropy_cache_load to YES.

### DIFF
--- a/extra/common-base-setting/patches/boot/loader.conf.extra
+++ b/extra/common-base-setting/patches/boot/loader.conf.extra
@@ -1,4 +1,4 @@
 # hw.syscons.disable=1
 hw.psm.synaptics_support="1"
 net.inet.ip.fw.default_to_accept="1"
-entropy_cache_load="NO"
+entropy_cache_load="YES"


### PR DESCRIPTION
This change is needed to remediate the following error.
Oct 29 09:02:19  kernel: arc4random: no preloaded entropy cache

Submitted an earlier pull request to add /boot/entropy file for entropy_cache_load="YES" to work correctly.