### PR TITLE
Added pulseaudio and systemmonitor KDE packages.

### DIFF
--- a/packages/kde
+++ b/packages/kde
@@ -482,7 +482,9 @@ plasma5-plasma-browser-integration
 plasma5-plasma-desktop
 plasma5-plasma-disks
 plasma5-plasma-integration
+plasma5-plasma-pa
 plasma5-plasma-sdk
+plasma5-plasma-systemmonitor
 plasma5-plasma-workspace
 plasma5-plasma-workspace-wallpapers
 plasma5-polkit-kde-agent-1-5.21.5


### PR DESCRIPTION
plasma5-plasma-pa needed for audio.
plasma5-plasma-systemmonitor needed for viewing system performance.