### PR TITLE
Update xorgproto packag name

### DIFF
--- a/packages/kde
+++ b/packages/kde
@@ -683,7 +683,7 @@ xorg-fonts-truetype
 xorg-fonts-type1
 xorg-libraries
 xorg-server
-xorgproto-2020.1
+xorgproto-2021.4
 xpr
 xprop
 xrandr


### PR DESCRIPTION
Changed package name from xorgproto-2020.1 to xorgproto-2021.4.