### PR TITLE
Remove scripts from cwd

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e -u
 
-export cwd="`realpath | sed 's|/scripts||g'`"
+export cwd="`realpath`"
 # Only run as superuser
 if [ "$(id -u)" != "0" ]; then
   echo "This script must be run as root" 1>&2


### PR DESCRIPTION
As the build.sh script was moved from a scripts directory to the ghostbsd-build root directory, the sed function to remove scripts from path is no longer necessary. Also, the scripts directory no longer exists and was deprecated a very long time ago.