### PR TITLE
Add hw-probe to ISO

### DIFF
--- a/packages/mate
+++ b/packages/mate
@@ -18,6 +18,7 @@ ghostbsd-mate
 ghostbsd-utils
 git
 gstreamer1-plugins-neon
+hw-probe
 nss_mdns
 pc-sysinstall
 pkg

--- a/packages/xfce
+++ b/packages/xfce
@@ -20,6 +20,7 @@ ghostbsd-xfce-themes
 git
 gnome-keyring
 gstreamer1-plugins-neon
+hw-probe
 nss_mdns
 nvidia-driver
 pc-sysinstall


### PR DESCRIPTION
Add hw-probe for users to be able to check hardware compatibility when using live environment.