### PR TITLE
Fix fetch_x_drivers_packages grep

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -164,9 +164,9 @@ packages_software()
 fetch_x_drivers_packages()
 {
   if [ "${build_type}" = "release" ] ; then
-    pkg_url=$(pkg-static -R pkg/ -vv | grep '/stable' | cut -d '"' -f2)
+    pkg_url=$(pkg-static -R pkg/ -vv | grep '/stable.*/latest' | cut -d '"' -f2)
   else
-    pkg_url=$(pkg-static -R pkg/ -vv | grep '/unstable' | cut -d '"' -f2)
+    pkg_url=$(pkg-static -R pkg/ -vv | grep '/unstable.*/latest' | cut -d '"' -f2)
   fi
   mkdir ${release}/xdrivers
   yes | pkg -R "${cwd}/pkg/" update


### PR DESCRIPTION
The grep was getting the /latest and base URL.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes an issue in the fetch_x_drivers_packages function where the grep command was incorrectly matching URLs, causing it to capture both the base URL and the '/latest' URL. The updated grep pattern now correctly matches the '/latest' URL for both stable and unstable builds.

- **Bug Fixes**:
    - Corrected the grep pattern in fetch_x_drivers_packages to accurately match the '/latest' URL for both stable and unstable builds.

<!-- Generated by sourcery-ai[bot]: end summary -->