### PR TITLE
removed GhostBSD-ipfilter from base packages

### DIFF
--- a/packages/base
+++ b/packages/base
@@ -87,7 +87,6 @@ GhostBSD-inetd
 GhostBSD-inetd-man
 GhostBSD-ipf
 GhostBSD-ipf-man
-GhostBSD-ipfilter
 GhostBSD-ipfw
 GhostBSD-ipfw-man
 GhostBSD-iscsi


### PR DESCRIPTION
GhostBSD-ipfilter got merged with GhostBSD-ipf