### PR TITLE
Add hgame to kld_list

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -182,7 +182,7 @@ rc()
   chroot ${release} touch /etc/rc.conf
   chroot ${release} sysrc hostname='livecd'
   chroot ${release} sysrc zfs_enable="YES"
-  chroot ${release} sysrc kld_list="linux linux64 cuse fusefs"
+  chroot ${release} sysrc kld_list="linux linux64 cuse fusefs hgame"
   chroot ${release} sysrc linux_enable="YES"
   chroot ${release} sysrc devfs_enable="YES"
   chroot ${release} sysrc devfs_system_ruleset="devfsrules_common"


### PR DESCRIPTION
The hgame driver "provides support for generic game controllers" which is extremely helpful for a desktop implementation of an operating system since most people like games. Some games throw fatal errors if it is not loaded even if a gamepad is not intended to be connected.

I see this as a fairly harmless quality of life / convenience change.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add 'hgame' to the kld_list in the build script to enable support for generic game controllers, enhancing the user experience by preventing fatal errors in some games.

Build:
- Add 'hgame' to the kld_list in the build script to support generic game controllers.

<!-- Generated by sourcery-ai[bot]: end summary -->