### PR TITLE
Update live_user in desktop scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -270,7 +270,14 @@ boot()
   cp LICENSE ${cd_root}/LICENSE
   cp -R boot/ ${cd_root}/boot/
   mkdir ${cd_root}/etc
-  cd "${cwd}" && zpool export ghostbsd && while zpool status ghostbsd >/dev/null; do :; done 2>/dev/null
+
+  # Try to unmount dev and release if mounted
+  umount ${release}/dev >/dev/null 2>/dev/null || true
+  umount ${release} >/dev/null 2>/dev/null || true
+  
+  # Export ZFS pool and ensure it's clean
+  zpool export ghostbsd
+  while zpool status ghostbsd >/dev/null; do :; done 2>/dev/null
 }
 
 image()

--- a/common_config/autologin.sh
+++ b/common_config/autologin.sh
@@ -5,12 +5,12 @@ set -e -u
 ghostbsd_setup_autologin()
 {
   {
-    echo "# ${liveuser} user autologin"
-    echo "${liveuser}:\\"
-    echo ":al=${liveuser}:ht:np:sp#115200:"
+    echo "# ${live_user} user autologin"
+    echo "${live_user}:\\"
+    echo ":al=${live_user}:ht:np:sp#115200:"
   } >> "${release}/etc/gettytab"
-  sed -i "" "/ttyv0/s/Pc/${liveuser}/g" "${release}/etc/ttys"
-  mkdir -p "${release}/home/${liveuser}/.config/fish"
+  sed -i "" "/ttyv0/s/Pc/${live_user}/g" "${release}/etc/ttys"
+  mkdir -p "${release}/home/${live_user}/.config/fish"
   printf "set tty (tty)
   if test \$tty = \"/dev/ttyv0\"
     sudo xconfig auto
@@ -21,8 +21,8 @@ ghostbsd_setup_autologin()
     sleep 1
     startx
   end
-" > "${release}/home/${liveuser}/.config/fish/config.fish"
-  chmod 765 "${release}/home/${liveuser}/.config/fish/config.fish"
+" > "${release}/home/${live_user}/.config/fish/config.fish"
+  chmod 765 "${release}/home/${live_user}/.config/fish/config.fish"
 
   # setup root
   mkdir -p "${release}/root/.config/fish"
@@ -37,12 +37,12 @@ ghostbsd_setup_autologin()
 community_setup_autologin()
 {
   {
-    echo "# ${liveuser} user autologin"
-    echo "${liveuser}:\\"
-    echo ":al=${liveuser}:ht:np:sp#115200:"
+    echo "# ${live_user} user autologin"
+    echo "${live_user}:\\"
+    echo ":al=${live_user}:ht:np:sp#115200:"
   } >> "${release}/etc/gettytab"
-  sed -i "" "/ttyv0/s/Pc/${liveuser}/g" "${release}/etc/ttys"
-  mkdir -p "${release}/home/${liveuser}/.config/fish"
+  sed -i "" "/ttyv0/s/Pc/${live_user}/g" "${release}/etc/ttys"
+  mkdir -p "${release}/home/${live_user}/.config/fish"
   if [ -f "${release}/usr/local/bin/xconfig" ] ; then
     printf "if not test -f /tmp/.xstarted
   touch /tmp/.xstarted
@@ -57,7 +57,7 @@ community_setup_autologin()
     startx
   end
 end
-" > "${release}/home/${liveuser}/.config/fish/config.fish"
-  chmod 765 "${release}/home/${liveuser}/.config/fish/config.fish"
+" > "${release}/home/${live_user}/.config/fish/config.fish"
+  chmod 765 "${release}/home/${live_user}/.config/fish/config.fish"
   fi
 }

--- a/common_config/setuser.sh
+++ b/common_config/setuser.sh
@@ -5,20 +5,20 @@ set -e -u
 set_user()
 {
   chroot "${release}" pw usermod -s /usr/local/bin/fish -n root
-  chroot "${release}" pw useradd "${liveuser}" \
-  -c "GhostBSD Live User" -d "/home/${liveuser}" \
+  chroot "${release}" pw useradd "${live_user}" \
+  -c "GhostBSD Live User" -d "/home/${live_user}" \
   -g wheel -G operator -m -s /usr/local/bin/fish -k /usr/share/skel -w none
 }
 
 ghostbsd_setup_liveuser()
 {
   set_user
-  chroot "${release}" su "${liveuser}" -c "mkdir -p /home/${liveuser}/.config/gtk-3.0"
-  chroot "${release}" su "${liveuser}" -c "echo '[Settings]' >> /home/${liveuser}/.config/gtk-3.0/settings.ini"
-  chroot "${release}" su "${liveuser}" -c "echo 'gtk-application-prefer-dark-theme = false' >> /home/${liveuser}/.config/gtk-3.0/settings.ini"
-  chroot "${release}" su "${liveuser}" -c "echo 'gtk-theme-name = Vimix' >> /home/${liveuser}/.config/gtk-3.0/settings.ini"
-  chroot "${release}" su "${liveuser}" -c "echo 'gtk-icon-theme-name = Vivacious-Colors-Dark' >> /home/${liveuser}/.config/gtk-3.0/settings.ini"
-  chroot "${release}" su "${liveuser}" -c "echo 'gtk-font-name = Droid Sans Bold 12' >> /home/${liveuser}/.config/gtk-3.0/settings.ini"
+  chroot "${release}" su "${live_user}" -c "mkdir -p /home/${live_user}/.config/gtk-3.0"
+  chroot "${release}" su "${live_user}" -c "echo '[Settings]' >> /home/${live_user}/.config/gtk-3.0/settings.ini"
+  chroot "${release}" su "${live_user}" -c "echo 'gtk-application-prefer-dark-theme = false' >> /home/${live_user}/.config/gtk-3.0/settings.ini"
+  chroot "${release}" su "${live_user}" -c "echo 'gtk-theme-name = Vimix' >> /home/${live_user}/.config/gtk-3.0/settings.ini"
+  chroot "${release}" su "${live_user}" -c "echo 'gtk-icon-theme-name = Vivacious-Colors-Dark' >> /home/${live_user}/.config/gtk-3.0/settings.ini"
+  chroot "${release}" su "${live_user}" -c "echo 'gtk-font-name = Droid Sans Bold 12' >> /home/${live_user}/.config/gtk-3.0/settings.ini"
   mkdir -p "${release}/root/.config/gtk-3.0"
   {
     echo '[Settings]'
@@ -32,11 +32,11 @@ ghostbsd_setup_liveuser()
 community_setup_liveuser()
 {
   set_user
-  chroot "${release}" su "${liveuser}" -c "mkdir -p /home/${liveuser}/Desktop"
+  chroot "${release}" su "${live_user}" -c "mkdir -p /home/${live_user}/Desktop"
 
   if [ -e "${release}/usr/local/share/applications/gbi.desktop" ] ; then
-   chroot "${release}" su "${liveuser}" -c  "cp -af /usr/local/share/applications/gbi.desktop /home/${liveuser}/Desktop"
-   chroot "${release}" su "${liveuser}" -c  "chmod +x /home/${liveuser}/Desktop/gbi.desktop"
-   sed -i '' -e 's/NoDisplay=true/NoDisplay=false/g' "${release}/home/${liveuser}/Desktop/gbi.desktop"
+   chroot "${release}" su "${live_user}" -c  "cp -af /usr/local/share/applications/gbi.desktop /home/${live_user}/Desktop"
+   chroot "${release}" su "${live_user}" -c  "chmod +x /home/${live_user}/Desktop/gbi.desktop"
+   sed -i '' -e 's/NoDisplay=true/NoDisplay=false/g' "${release}/home/${live_user}/Desktop/gbi.desktop"
   fi
 }

--- a/desktop_config/mate.sh
+++ b/desktop_config/mate.sh
@@ -15,11 +15,11 @@ lightdm_setup()
 
 setup_xinit()
 {
-  chroot "${release}" su "${liveuser}" -c "echo 'gsettings set org.mate.SettingsDaemon.plugins.housekeeping active true &' > /home/${liveuser}/.xinitrc"
-  chroot "${release}" su "${liveuser}" -c "echo 'gsettings set org.mate.screensaver lock-enabled false &' >> /home/${liveuser}/.xinitrc"
-  chroot "${release}" su "${liveuser}" -c "echo 'gsettings set org.mate.lockdown disable-lock-screen true &' >> /home/${liveuser}/.xinitrc"
-  chroot "${release}" su "${liveuser}" -c "echo 'gsettings set org.mate.lockdown disable-user-switching true &' >> /home/${liveuser}/.xinitrc"
-  chroot "${release}" su "${liveuser}" -c "echo 'exec ck-launch-session mate-session' >> /home/${liveuser}/.xinitrc"
+  chroot "${release}" su "${live_user}" -c "echo 'gsettings set org.mate.SettingsDaemon.plugins.housekeeping active true &' > /home/${live_user}/.xinitrc"
+  chroot "${release}" su "${live_user}" -c "echo 'gsettings set org.mate.screensaver lock-enabled false &' >> /home/${live_user}/.xinitrc"
+  chroot "${release}" su "${live_user}" -c "echo 'gsettings set org.mate.lockdown disable-lock-screen true &' >> /home/${live_user}/.xinitrc"
+  chroot "${release}" su "${live_user}" -c "echo 'gsettings set org.mate.lockdown disable-user-switching true &' >> /home/${live_user}/.xinitrc"
+  chroot "${release}" su "${live_user}" -c "echo 'exec ck-launch-session mate-session' >> /home/${live_user}/.xinitrc"
   echo "exec ck-launch-session mate-session" > "${release}/root/.xinitrc"
   echo "exec ck-launch-session mate-session" > "${release}/usr/share/skel/dot.xinitrc"
 }

--- a/desktop_config/mate_oem.sh
+++ b/desktop_config/mate_oem.sh
@@ -16,10 +16,10 @@ lightdm_setup()
 
 setup_xinit()
 {
-  echo "exec marco &" > "${release}/home/${liveuser}/.xinitrc"
-  echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/Lake_View.jpg &" >> "${release}/home/${liveuser}/.xinitrc"
-  echo "exec sudo install-station" >> "${release}/home/${liveuser}/.xinitrc"
-  chmod 765 "${release}/home/${liveuser}/.xinitrc"
+  echo "exec marco &" > "${release}/home/${live_user}/.xinitrc"
+  echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/Lake_View.jpg &" >> "${release}/home/${live_user}/.xinitrc"
+  echo "exec sudo install-station" >> "${release}/home/${live_user}/.xinitrc"
+  chmod 765 "${release}/home/${live_user}/.xinitrc"
   # root
   echo "exec marco &" > "${release}/root/.xinitrc"
   echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/Lake_View.jpg &" >> "${release}/root/.xinitrc"

--- a/desktop_config/xfce.sh
+++ b/desktop_config/xfce.sh
@@ -15,7 +15,7 @@ lightdm_setup()
 
 setup_xinit()
 {
-  chroot "${release}" su "${liveuser}" -c "echo 'exec ck-launch-session startxfce4' > /home/${liveuser}/.xinitrc"
+  chroot "${release}" su "${live_user}" -c "echo 'exec ck-launch-session startxfce4' > /home/${live_user}/.xinitrc"
   echo "exec ck-launch-session startxfce4" > "${release}/root/.xinitrc"
   echo "exec ck-launch-session startxfce4" > "${release}/root/.xinitrc"
   echo "exec ck-launch-session startxfce4" > "${release}/usr/share/skel/dot.xinitrc"


### PR DESCRIPTION
Found liveuser was change to live_user in the build.sh script. Made changes to the desktop scripts to align with build.sh script.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Align variable naming in desktop scripts with the build.sh script by changing 'liveuser' to 'live_user'.

Enhancements:
- Update desktop scripts to use 'live_user' instead of 'liveuser' for consistency with the build.sh script.

<!-- Generated by sourcery-ai[bot]: end summary -->