### PR TITLE
Optimize find usage in script to reduce unnecessary commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,7 +128,6 @@ workspace()
     zpool destroy ghostbsd 2>/dev/null
     exit 1
   fi
-  fi
 }
 
 base()

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,10 @@ case $kernel in
     ;;
 esac
 
-desktop_list=$(find packages -type f | grep base | cut -d '/' -f2 | tr -s '\n' ' ')
+# Use find to locate base files and extract filenames directly, converting newlines to spaces
+desktop_list=$(find packages -type f -name '*base*' -exec basename {} \; | tr '\n' ' ')
+
+# Find all files in the desktop_config directory
 desktop_config_list=$(find desktop_config -type f)
 
 help_function()

--- a/build.sh
+++ b/build.sh
@@ -123,10 +123,11 @@ workspace()
   mkdir -p ${livecd} ${base} ${iso} ${software_packages} ${base_packages} ${release}
   truncate -s 6g ${livecd}/pool.img
   mdconfig -f ${livecd}/pool.img -u 0
-  zpool create -O mountpoint=${release} -O compression=zstd-9 ghostbsd /dev/md0
-  if [ $? -ne 0 ]; then
-    echo "Failed to create ZFS pool ghostbsd"
+  if ! zpool create -O mountpoint="${release}" -O compression=zstd-9 ghostbsd /dev/md0; then
+    echo "Failed to create ZFS pool 'ghostbsd'. Command: zpool create -O mountpoint=${release} -O compression=zstd-9 ghostbsd /dev/md0"
+    zpool destroy ghostbsd 2>/dev/null
     exit 1
+  fi
   fi
 }
 


### PR DESCRIPTION
Optimize find usage in script to reduce unnecessary commands

- Replaced grep and cut with more efficient find options
- Used basename in find to directly extract filenames
- Simplified tr usage to convert newlines into spaces

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Optimize the build.sh script by enhancing the find command usage to reduce unnecessary commands and improve efficiency. Add error handling for ZFS pool creation and implement a timeout for exporting the ZFS pool to ensure reliability.

Bug Fixes:
- Add error handling for ZFS pool creation to exit the script if the pool creation fails.
- Implement a timeout mechanism for exporting the ZFS pool to ensure it completes within a specified time frame.

Enhancements:
- Optimize the use of the find command in build.sh by replacing grep and cut with more efficient find options and using basename to directly extract filenames.
- Simplify the tr command usage to convert newlines into spaces in the script.

<!-- Generated by sourcery-ai[bot]: end summary -->