### PR TITLE
Add POOL_Size variable to improve flexibility and maintainability

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -132,7 +132,8 @@ workspace()
   mkdir -p ${livecd} ${base} ${iso} ${software_packages} ${base_packages} ${release}
 
   # Create a new pool image file of 6GB
-  truncate -s 6g ${livecd}/pool.img
+  POOL_SIZE='6g'
+  truncate -s ${POOL_SIZE} ${livecd}/pool.img
   
   # Attach the pool image as a memory disk
   mdconfig -f ${livecd}/pool.img -u 0


### PR DESCRIPTION
Define a variable, POOL_SIZE='6g', to makes it easier to adjust the size in the future if needed.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Define a POOL_SIZE variable in the build script to allow easier adjustments to the pool image file size in the future.

Enhancements:
- Introduce a POOL_SIZE variable to define the pool image file size, improving flexibility and maintainability.

<!-- Generated by sourcery-ai[bot]: end summary -->