### PR TITLE
Add live user with specific UID of 1100

### DIFF
--- a/common_config/setuser.sh
+++ b/common_config/setuser.sh
@@ -5,7 +5,7 @@ set -e -u
 set_user()
 {
   chroot "${release}" pw usermod -s /usr/local/bin/fish -n root
-  chroot "${release}" pw useradd "${live_user}" \
+  chroot "${release}" pw useradd "${live_user}" -u 1100 \
   -c "GhostBSD Live User" -d "/home/${live_user}" \
   -g wheel -G operator -m -s /usr/local/bin/fish -k /usr/share/skel -w none
 }


### PR DESCRIPTION
- Updated the user creation script to assign the live user a specific UID (1100). This ensures consistency in the user ID for the installed environment.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the user creation script by assigning a specific UID (1100) to the live user to ensure consistent user ID across installations.

Enhancements:
- Assign a specific UID (1100) to the live user in the user creation script to ensure consistency in the user ID for the installed environment.

<!-- Generated by sourcery-ai[bot]: end summary -->