### PR TITLE
Corrected tmpfs entry in fstab.extra

### DIFF
--- a/common_config/base-setting/patches/etc/fstab.extra
+++ b/common_config/base-setting/patches/etc/fstab.extra
@@ -1,5 +1,5 @@
 proc /proc procfs rw 0 0
 linproc /compat/linux/proc linprocfs rw 0 0
-tmpsf /tmp tmpfs rw,mode=1777 0 0
+tmpfs /tmp tmpfs rw,mode=1777 0 0
 linsysfs /compat/linux/sys linsysfs rw 0 0
 fdesc /dev/fd fdescfs rw 0 0


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the tmpfs entry in the fstab.extra file to ensure proper mounting.