### PR TITLE
Enable HID support by default in GhostBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -243,6 +243,9 @@ rc()
   chroot ${release} sysrc avahi_dnsconfd_enable="YES"
   chroot ${release} sysrc ntpd_enable="YES"
   chroot ${release} sysrc ntpd_sync_on_start="YES"
+  chroot ${release} sysrc uhid_load="YES"
+  chroot ${release} sysrc hid_load="YES"
+  chroot ${release} sysrc hidraw_load="YES"
 }
 
 ghostbsd_config()


### PR DESCRIPTION
Added uhid, hid, and hidraw modules to be loaded by default via sysrc.

This ensures better compatibility with USB HID devices for GhostBSD users.

## Summary by Sourcery

Build:
- Enable the `uhid`, `hid`, and `hidraw` kernel modules in the base system configuration.