### PR TITLE
Removed automount related code.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -250,9 +250,6 @@ ghostbsd_config()
   # echo "gop set 0" >> ${release}/boot/loader.rc.local
   mkdir -p ${release}/usr/local/share/ghostbsd
   echo "${desktop}" > ${release}/usr/local/share/ghostbsd/desktop
-  # bypass automount for live iso
-  mv ${release}/usr/local/etc/devd/automount_devd.conf ${release}/usr/local/etc/devd/automount_devd.conf.skip
-  mv ${release}/usr/local/etc/devd/automount_devd_localdisks.conf ${release}/usr/local/etc/devd/automount_devd_localdisks.conf.skip
   # Mkdir for linux compat to ensure /etc/fstab can mount when booting LiveCD
   chroot ${release} mkdir -p /compat/linux/dev/shm
   # Add /boot/entropy file


### PR DESCRIPTION
It is removed from the default installation.

## Summary by Sourcery

Remove automounting support from the default installation.

Enhancements:
- Remove automount configuration files.

Chores:
- Disable automounting on boot.