### PR TITLE
Tuning memory usage of the live session.

### DIFF
--- a/boot/loader.conf
+++ b/boot/loader.conf
@@ -36,7 +36,7 @@ zfs_load="YES"
 # Tune arc for lower memory usage during LiveCD session
 # vm.kmem_size="512M"
 # vm.kmem_size_max="1024M"
-vfs.zfs.arc_max="512M"
+vfs.zfs.arc_max="64M"
 # vfs.zfs.vdev.cache.size="5M"
 
 # For XHCI Mouse Support

--- a/boot/loader.conf
+++ b/boot/loader.conf
@@ -39,6 +39,9 @@ zfs_load="YES"
 vfs.zfs.arc_max="64M"
 # vfs.zfs.vdev.cache.size="5M"
 
+# We can safely disable pre-fetch as we are already running from memory.
+vfs.zfs.prefetch_disable="1"
+
 # For XHCI Mouse Support
 hw.usb.usbhid.enable="1"
 usbhid_load="YES"

--- a/init.sh.in
+++ b/init.sh.in
@@ -48,7 +48,7 @@ echo "==> Mount swap-based memdisk"
 mdconfig -a -t swap -s ${memdisk_size}g -u 1 >/dev/null 2>/dev/null
 # We can safely disable pre-fetch as we are already running from memory.
 sysctl vfs.zfs.prefetch_disable=1
-zpool create livecd -O primarycache=none /dev/md1 >/dev/null 2>/dev/null
+zpool create livecd /dev/md1 >/dev/null 2>/dev/null
 zfs set compression=zstd-9 livecd
 zfs set primarycache=none livecd
 echo "==> Replicate system image to swap-based memdisk"

--- a/init.sh.in
+++ b/init.sh.in
@@ -46,7 +46,9 @@ fi
 
 echo "==> Mount swap-based memdisk"
 mdconfig -a -t swap -s ${memdisk_size}g -u 1 >/dev/null 2>/dev/null
-zpool create livecd /dev/md1 >/dev/null 2>/dev/null
+# We can safely disable pre-fetch as we are already running from memory.
+sysctl vfs.zfs.prefetch_disable=1
+zpool create livecd -O primarycache=none /dev/md1 >/dev/null 2>/dev/null
 zfs set compression=zstd-9 livecd
 zfs set primarycache=none livecd
 echo "==> Replicate system image to swap-based memdisk"

--- a/init.sh.in
+++ b/init.sh.in
@@ -46,7 +46,7 @@ fi
 
 echo "==> Mount swap-based memdisk"
 mdconfig -a -t swap -s ${memdisk_size}g -u 1 >/dev/null 2>/dev/null
-zpool create livecd -O primarycache=none /dev/md1 >/dev/null 2>/dev/null
+zpool create -O primarycache=none livecd /dev/md1 >/dev/null 2>/dev/null
 zfs set compression=zstd-9 livecd
 echo "==> Replicate system image to swap-based memdisk"
 dd if=/cdrom/data/system.img status=progress bs=1M | zfs recv -F livecd

--- a/init.sh.in
+++ b/init.sh.in
@@ -46,11 +46,8 @@ fi
 
 echo "==> Mount swap-based memdisk"
 mdconfig -a -t swap -s ${memdisk_size}g -u 1 >/dev/null 2>/dev/null
-# We can safely disable pre-fetch as we are already running from memory.
-sysctl vfs.zfs.prefetch_disable=1
-zpool create livecd /dev/md1 >/dev/null 2>/dev/null
+zpool create livecd -O primarycache=none /dev/md1 >/dev/null 2>/dev/null
 zfs set compression=zstd-9 livecd
-zfs set primarycache=none livecd
 echo "==> Replicate system image to swap-based memdisk"
 dd if=/cdrom/data/system.img status=progress bs=1M | zfs recv -F livecd
 kenv init_shell="/rescue/sh"


### PR DESCRIPTION
Upon testing from @pkgdemon on telegram, we can safely trim down ARC to 64 Megabytes, and disable ZFS pre-fetching in the live session.

This will help users on really memory-constrained systems boot and install GhostBSD. We may want to have a warning for users in this scenario in the installer to avoid running additional programs while the system is installing as it will eat up ram. 

We can safely disable pre-fetching for ZFS in init.sh as it is running from memory anyways.

Thoughts?

## Summary by Sourcery

This pull request tunes the memory usage of the live session by reducing the maximum ARC size and disabling ZFS pre-fetching. This change will help users on memory-constrained systems to boot and install GhostBSD.

Enhancements:
- Reduced the maximum ARC size to 64MB to lower memory usage during the live session.
- Disabled ZFS pre-fetching in the live session.