### PR TITLE
clear /tmp by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -233,6 +233,7 @@ rc()
   chroot ${release} sysrc avahi_dnsconfd_enable="YES"
   chroot ${release} sysrc ntpd_enable="YES"
   chroot ${release} sysrc ntpd_sync_on_start="YES"
+  chroot ${release} sysrc clear_tmp_enable="YES"
 }
 
 ghostbsd_config()


### PR DESCRIPTION
I was messing with @vic-thacker's scripts in /tmp and noticed that /tmp wasn't being cleared by default. IMHO, this is a weird behaviour. By not clearing /tmp, we run the risk of filling up / with unneeded temporary files that running a desktop system creates, like dbus's tmp files for example. This *shouldn't* break live sessions, though I haven't tested a live ISO built with this commit. Thoughts?

## Summary by Sourcery

Enable clearing of temporary files in /tmp directory by default during system configuration

Enhancements:
- Improve system disk space management by automatically removing unnecessary temporary files

Chores:
- Add system configuration to automatically clear temporary files at system startup