### PR TITLE
Ensure correct ZFS root dataset is set in loader.conf

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -292,6 +292,9 @@ boot()
   cp -R boot/ ${cd_root}/boot/
   mkdir ${cd_root}/etc
 
+  # Set the correct root mount point for ZFS
+  echo 'vfs.root.mountfrom="zfs:ghostbsd/ROOT/default"' >> "${cd_root}/boot/loader.conf"
+
   # Try to unmount dev and release if mounted
   umount ${release}/dev >/dev/null 2>/dev/null || true
   umount ${release} >/dev/null 2>/dev/null || true


### PR DESCRIPTION
Added `vfs.root.mountfrom="zfs:ghostbsd/ROOT/default"` to the boot configuration to prevent boot failures on systems where the boot device appears as `da0` instead of `ada0` (e.g., USB-based installations on Mac Minis). This ensures the system correctly locates the root ZFS dataset regardless of device naming during boot.

Also improves robustness across varying hardware configurations by avoiding hardcoded device assumptions.

## Summary by Sourcery

Modify boot configuration to ensure reliable ZFS root dataset mounting across different hardware configurations

Bug Fixes:
- Prevent potential boot failures on systems with variable device naming by specifying the exact ZFS root dataset

Enhancements:
- Improve boot configuration robustness by explicitly setting the ZFS root mount point in loader.conf