### PR TITLE
Adding missing fusefs

### DIFF
--- a/packages/common
+++ b/packages/common
@@ -2,10 +2,15 @@ cups
 cups-filters
 drm-kmod
 evolution
+exfat-utils
 firefox
 fish
 foomatic-db
+fusefs-exfat
 fusefs-ext2
+fusefs-hfsfuse
+fusefs-lkl
+fusefs-ntfs
 gbi
 ghostbsd-fonts
 ghostbsd-icons


### PR DESCRIPTION
## Summary by Sourcery

Add missing fusefs package to the common packages directory