### PR TITLE
Remove apps to remediate ISO memory exhaustion issue

### DIFF
--- a/packages/common
+++ b/packages/common
@@ -2,7 +2,6 @@ cups
 cups-filters
 drm-kmod
 exfat-utils
-firefox
 fish
 foomatic-db
 fusefs-exfat
@@ -23,6 +22,7 @@ rhythmbox
 shotwell
 slick-greeter
 system-config-printer
+ungoogled-chromium
 unzip
 webrtc-audio-processing
 xconfig


### PR DESCRIPTION
Removed vlc and evolution from the common file

## Summary by Sourcery

Enhancements:
- Remove vlc and evolution packages from the common package list.