### PR TITLE
Fix wifi for 14.3

### DIFF
--- a/packages/drivers
+++ b/packages/drivers
@@ -6,6 +6,7 @@ gstreamer1-plugins-neon
 realtek-re-kmod
 utouch-kmod
 virtualbox-ose-additions
+wifi-firmware-kmod
 xf86-input-evdev
 xf86-input-joystick
 xf86-input-keyboard


### PR DESCRIPTION
* Without this intel wifi devices that require iwlwifi will not work.

## Summary by Sourcery

Bug Fixes:
- Restore support for Intel wireless devices by adding the iwlwifi driver for version 14.3