### PR TITLE
Create missing /compat/linux directories

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -243,6 +243,8 @@ ghostbsd_config()
   echo "${desktop}" > ${release}/usr/local/share/ghostbsd/desktop
   # Mkdir for linux compat to ensure /etc/fstab can mount when booting LiveCD
   chroot ${release} mkdir -p /compat/linux/dev/shm
+  chroot ${release} mkdir -p /compat/linux/proc
+  chroot ${release} mkdir -p /compat/linux/sys
   # Add /boot/entropy file
   chroot ${release} touch /boot/entropy
   # default GhostBSD to local time instead of UTC


### PR DESCRIPTION
These are also needed.

## Summary by Sourcery

Add missing Linux compatibility directories in the LiveCD chroot setup

Enhancements:
- Create /compat/linux/proc directory in the release chroot
- Create /compat/linux/sys directory in the release chroot