### PR TITLE
Remove ghostbsd-xfce-theme from packages/xfce

### DIFF
--- a/packages/xfce
+++ b/packages/xfce
@@ -1,6 +1,5 @@
 evince-lite
 ffmpegthumbnailer
 ghostbsd-xfce-settings
-ghostbsd-xfce-themes
 ghostbsd-xfce4
 xarchiver


### PR DESCRIPTION
It has been replaced by ghostbsd-gkt-them and added to the ghostbsd-xfce4 package dependency.

## Summary by Sourcery

Update XFCE package dependencies by removing the old ghostbsd-xfce-theme and introducing the ghostbsd-gtk-theme dependency for ghostbsd-xfce4.

Enhancements:
- Replace ghostbsd-xfce-theme with ghostbsd-gtk-theme in the XFCE package dependency list
- Add ghostbsd-gtk-theme as a dependency of the ghostbsd-xfce4 package