### PR TITLE
Fix vital pkg for XFCE

### DIFF
--- a/packages/vital/xfce
+++ b/packages/vital/xfce
@@ -1,4 +1,4 @@
 ffmpegthumbnailer
 ghostbsd-xfce4
 ghostbsd-xfce-settings
-ghostbsd-xfce-themes
+ghostbsd-gtk-themes


### PR DESCRIPTION
Fixes name of vital package that has change to ghostbsd-gtk-themes.