### PR TITLE
Adding timestamp for testing and unstable builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -225,8 +225,10 @@ zfs_arc_restore() {
     
     if [ "$original_arc_max" != "0" ]; then
         log "Restoring original ZFS ARC settings..."
+        # shellcheck disable=SC2086
         sysctl vfs.zfs.arc_max=$original_arc_max >/dev/null 2>&1 || true
         if [ "$original_arc_min" != "0" ]; then
+            # shellcheck disable=SC2086
             sysctl vfs.zfs.arc_min=$original_arc_min >/dev/null 2>&1 || true
         fi
         

--- a/build.sh
+++ b/build.sh
@@ -479,7 +479,7 @@ set_ghostbsd_version()
     version="-$(cat ${release}/etc/version)"
   fi
   iso_path="${iso}/${label}${version}${release_stamp}${time_stamp}${community}.iso"
-  log "ISO will be created as: $(basename $iso_path)"
+  log "ISO will be created as: $(basename "$iso_path")"
 }
 
 # Enhanced packages_software with additional login.conf protection
@@ -731,7 +731,7 @@ uzip()
         current_file="system.img"
       fi
       
-      if [ $current_size -gt 0 ]; then
+      if [ "$current_size" -gt 0 ]; then
         current_mb=$((current_size / 1024 / 1024))
         log "${current_file} current size: ${current_mb}MB"
       fi

--- a/build.sh
+++ b/build.sh
@@ -630,9 +630,11 @@ ghostbsd_config()
 # Clean desktop_config function that avoids user creation conflicts
 desktop_config()
 {
+  # shellcheck disable=SC2218
   log "=== Configuring desktop environment: ${desktop} ==="
   
   # Source common configuration functions (but only call the safe ones)
+  # shellcheck disable=SC2218
   log "Loading common configuration functions..."
   . "${cwd}/common_config/base-setting.sh"
   . "${cwd}/common_config/gitpkg.sh" 

--- a/build.sh
+++ b/build.sh
@@ -83,7 +83,7 @@ elif [ "${build_type}" = "release" ] ; then
 elif [ "${build_type}" = "unstable" ] ; then
   PKG_CONF="GhostBSD_Unstable"
 else
-  printf "\t-b Build type: unstable, testing, or release"
+  printf "\t-b Build type: unstable, testing, or release\n"
   exit 1
 fi
 
@@ -469,8 +469,12 @@ EOF
 
 set_ghostbsd_version()
 {
-  if [ "${desktop}" = "test" ] ; then
-    version="$(date +%Y-%m-%d)"
+  if [ "${build_type}" = "testing" ] || [ "${build_type}" = "unstable" ] ; then
+    # Add date suffix for testing and unstable builds
+    base_version="-$(cat ${release}/etc/version)"
+    date_suffix="-$(date +%m-%d-%H)"
+    version="${base_version}${date_suffix}"
+    log "Adding date suffix for ${build_type} build: ${date_suffix}"
   else
     version="-$(cat ${release}/etc/version)"
   fi

--- a/common_config/setuser.sh
+++ b/common_config/setuser.sh
@@ -46,6 +46,7 @@ community_setup_liveuser()
    sed -i '' -e 's/NoDisplay=true/NoDisplay=false/g' "${release}/home/${live_user}/Desktop/gbi.desktop"
    # Trust desktop file for XFCE 4.18+ using checksum metadata
    if [ "${desktop}" = "xfce" ] ; then
+     # shellcheck disable=SC2016
      chroot "${release}" su - "${live_user}" -c '
        dbus-run-session -- sh -c "
          /usr/local/libexec/gvfsd >/dev/null 2>&1 &


### PR DESCRIPTION
## Summary by Sourcery

Add date-based suffix to version for testing and unstable builds and ensure build type usage message ends with a newline

Enhancements:
- Append date-based suffix to version for testing and unstable builds
- Log the added date suffix when building testing or unstable packages
- Ensure the build type usage message ends with a newline