### PR TITLE
Adding missing libz packages

### DIFF
--- a/packages/base
+++ b/packages/base
@@ -100,6 +100,8 @@ GhostBSD-libucl-lib32
 GhostBSD-libvgl
 GhostBSD-libvgl-lib32
 GhostBSD-libvmmapi
+GhostBSD-libz
+GhostBSD-libz-dev
 GhostBSD-lld
 GhostBSD-lldb
 GhostBSD-local-unbound


### PR DESCRIPTION
It did move from runtime to its own packages.

See https://github.com/ghostbsd/ghostbsd-src/pull/377/commits/32b6de9082ed4ea135f8464cce7a730360608d19 for more details

## Summary by Sourcery

Separate zlib into its own packages and include them in the base package list

Enhancements:
- Add libz (zlib) package to base packaging
- Add libz-devel (zlib headers) package to base packaging