### PR TITLE
Update wallpaper and Fix MATE OEM script.

### DIFF
--- a/desktop_config/mate_oem.sh
+++ b/desktop_config/mate_oem.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -e -u
 
 . "${cwd}/common_config/autologin.sh"
@@ -17,22 +16,18 @@ lightdm_setup()
 setup_xinit()
 {
   echo "exec marco &" > "${release}/home/${live_user}/.xinitrc"
-  echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/Lake_View.jpg &" >> "${release}/home/${live_user}/.xinitrc"
-  echo "exec sudo install-station" >> "${release}/home/${live_user}/.xinitrc"
+  # Todo update wallpaper for 26.01 also find a way to automate the wall paper
+  echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/blue-layered-stripes.jpg &" >> "${release}/home/${live_user}/.xinitrc"
+  echo "exec sudo install-station-init" >> "${release}/home/${live_user}/.xinitrc"
   chmod 765 "${release}/home/${live_user}/.xinitrc"
   # root
   echo "exec marco &" > "${release}/root/.xinitrc"
-  echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/Lake_View.jpg &" >> "${release}/root/.xinitrc"
+  echo "exec feh --bg-fill /usr/local/share/backgrounds/ghostbsd/blue-layered-stripes.jpg &" >> "${release}/root/.xinitrc"
   echo "exec setup-station" >> "${release}/root/.xinitrc"
 }
 
 patch_etc_files
 patch_loader_conf_d
-
-git_pc_sysinstall
-git_gbi
-git_install_station
-git_setup_station
 
 ghostbsd_setup_liveuser
 ghostbsd_setup_autologin


### PR DESCRIPTION
- Replace wallpaper with "blue-layered-stripes.jpg."
- Remove obsolete Git setup functions from script.

## Summary by Sourcery

Update the MATE OEM configuration script to use the new default wallpaper and simplify the live system setup.

Bug Fixes:
- Point the MATE OEM xinit configuration to the correct install-station-init command instead of the previous install-station command.

Enhancements:
- Switch the default MATE OEM wallpaper to blue-layered-stripes.jpg for both live user and root sessions.
- Remove obsolete Git-based setup functions from the MATE OEM provisioning flow to streamline system initialization.