### PR TITLE
Removed `xconfig` duplicate and `xorg-minimal` from package list

### DIFF
--- a/packages/mate
+++ b/packages/mate
@@ -1,7 +1,6 @@
 brisk-menu
 cursor-dmz-theme
 dconf-editor
-evolution
 freedesktop-sound-theme
 gbi
 ghostbsd-mate

--- a/packages/mate_oem
+++ b/packages/mate_oem
@@ -1,7 +1,6 @@
 brisk-menu
 cursor-dmz-theme
 dconf-editor
-evolution
 feh
 freedesktop-sound-theme
 ghostbsd-mate

--- a/packages/vital/mate_oem
+++ b/packages/vital/mate_oem
@@ -11,5 +11,3 @@ plank
 slick-greeter
 station-tweak
 webrtc-audio-processing
-xconfig
-xorg-minimal

--- a/packages/xfce
+++ b/packages/xfce
@@ -1,5 +1,4 @@
 evince-lite
-evolution
 ffmpegthumbnailer
 gbi
 ghostbsd-xfce-settings


### PR DESCRIPTION
Also remove evolution. I will let users show their email software.

## Summary by Sourcery

Enhancements:
- Remove duplicate and unnecessary packages (including xconfig, xorg-minimal, and evolution) from MATE, MATE OEM, vital MATE OEM, and XFCE package manifests.