### PR TITLE
Make Gershwin ISO use lightdm for now

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -239,10 +239,6 @@ rc()
   chroot ${release} sysrc moused_enable="YES"
   chroot ${release} sysrc dbus_enable="YES"
   chroot ${release} sysrc lightdm_enable="NO"
-  if [ "${desktop}" = "gershwin" ] ; then
-    chroot ${release} sysrc dshelper_enable="YES"
-    chroot ${release} sysrc loginwindow_enable="NO"
-  fi
   chroot ${release} sysrc webcamd_enable="YES"
   chroot ${release} sysrc firewall_enable="YES"
   chroot ${release} sysrc firewall_type="workstation"

--- a/desktop_config/gershwin.sh
+++ b/desktop_config/gershwin.sh
@@ -7,9 +7,10 @@ set -e -u
 . "${cwd}/common_config/finalize.sh"
 . "${cwd}/common_config/setuser.sh"
 
-loginwindow_setup()
+lightdm_setup()
 {
-  return 0
+  sed -i '' "s@#greeter-session=example-gtk-gnome@greeter-session=slick-greeter@" "${release}/usr/local/etc/lightdm/lightdm.conf"
+  sed -i '' "s@#user-session=default@user-session=gershwin@" "${release}/usr/local/etc/lightdm/lightdm.conf"
 }
 
 setup_xinit()
@@ -23,6 +24,7 @@ patch_etc_files
 patch_loader_conf_d
 community_setup_liveuser_gershwin
 community_setup_autologin_gershwin
+lightdm_setup
 loginwindow_setup
 setup_xinit
 final_setup

--- a/desktop_config/gershwin.sh
+++ b/desktop_config/gershwin.sh
@@ -25,6 +25,5 @@ patch_loader_conf_d
 community_setup_liveuser_gershwin
 community_setup_autologin_gershwin
 lightdm_setup
-loginwindow_setup
 setup_xinit
 final_setup

--- a/packages/gershwin
+++ b/packages/gershwin
@@ -1,2 +1,3 @@
 gbi
 gershwin
+slick-greeter


### PR DESCRIPTION
* Less work just to use lightdm for the moment
* Putting focus on getting ISO fully working again instead with installer

## Summary by Sourcery

Switch the Gershwin desktop ISO to use LightDM with a configured greeter and session instead of the previous login window integration.

Enhancements:
- Configure LightDM for the Gershwin ISO by setting the slick-greeter and gershwin user session in lightdm.conf.
- Simplify system service configuration by removing Gershwin-specific dshelper and loginwindow service setup from the build script.