### PR TITLE
Switch the default shell to zsh and update related configurations

### DIFF
--- a/common_config/autologin.sh
+++ b/common_config/autologin.sh
@@ -10,19 +10,16 @@ ghostbsd_setup_autologin()
     echo ":al=${live_user}:ht:np:sp#115200:"
   } >> "${release}/etc/gettytab"
   sed -i "" "/ttyv0/s/Pc/${live_user}/g" "${release}/etc/ttys"
-  mkdir -p "${release}/home/${live_user}/.config/fish"
-  printf "set tty (tty)
-  if test \$tty = \"/dev/ttyv0\"
-    sudo xconfig auto
-    sleep 1
-    sudo rm -rf /xdrivers
-    sleep 1
-    startx
-    sleep 1
-    startx
-  end
-" > "${release}/home/${live_user}/.config/fish/config.fish"
-  chmod 765 "${release}/home/${live_user}/.config/fish/config.fish"
+  cat > "${release}/home/${live_user}/.zshrc" <<'EOF'
+if [ "$(tty)" = "/dev/ttyv0" ]; then
+  sudo xconfig auto
+  sleep 1
+  startx
+  sleep 1
+  startx
+fi
+EOF
+  chmod 765 "${release}/home/${live_user}/.zshrc"
 
   # setup root
   printf "if [ \"\$(tty)\" = \"/dev/ttyv0\" ]; then
@@ -41,23 +38,18 @@ community_setup_autologin()
     echo ":al=${live_user}:ht:np:sp#115200:"
   } >> "${release}/etc/gettytab"
   sed -i "" "/ttyv0/s/Pc/${live_user}/g" "${release}/etc/ttys"
-  mkdir -p "${release}/home/${live_user}/.config/fish"
   if [ -f "${release}/usr/local/bin/xconfig" ] ; then
-    printf "if not test -f /tmp/.xstarted
+    cat > "${release}/home/${live_user}/.zshrc" <<'EOF'
+if [ ! -f /tmp/.xstarted ]; then
   touch /tmp/.xstarted
-  set tty (tty)
-  if test \$tty = \"/dev/ttyv0\"
+  if [ "$(tty)" = "/dev/ttyv0" ]; then
     sudo xconfig auto
     sleep 1
-    echo \"X configuation completed\"
-    sleep 1
-    sudo rm -rf /xdrivers
-    sleep 1
     startx
-  end
-end
-" > "${release}/home/${live_user}/.config/fish/config.fish"
-  chmod 765 "${release}/home/${live_user}/.config/fish/config.fish"
+  fi
+fi
+EOF
+    chmod 765 "${release}/home/${live_user}/.zshrc"
   fi
 }
 
@@ -76,10 +68,6 @@ community_setup_autologin_gershwin()
 if [ ! -f /tmp/.xstarted ]; then
   touch /tmp/.xstarted
   sudo xconfig auto
-  sleep 1
-  echo "X configuration completed"
-  sleep 1
-  sudo rm -rf /xdrivers
   sleep 1
   startx
 fi

--- a/common_config/setuser.sh
+++ b/common_config/setuser.sh
@@ -6,7 +6,7 @@ set_user()
 {
   chroot "${release}" pw useradd "${live_user}" -u 1100 \
   -c "GhostBSD Live User" -d "/home/${live_user}" \
-  -g wheel -G operator -m -s /usr/local/bin/fish -k /usr/share/skel -w none
+  -g wheel -G operator -m -s /usr/local/bin/zsh -k /usr/share/skel -w none
 }
 
 set_user_gershwin()

--- a/packages/common
+++ b/packages/common
@@ -2,7 +2,6 @@ cups
 cups-filters
 exfat-utils
 firefox
-fish
 foomatic-db
 fusefs-exfat
 fusefs-ext2
@@ -12,6 +11,7 @@ fusefs-ntfs
 ghostbsd-fonts
 ghostbsd-icons
 ghostbsd-utils
+ghostbsd-zsh-settings
 nss_mdns
 pc-sysinstall
 pkg

--- a/packages/drivers
+++ b/packages/drivers
@@ -3,6 +3,7 @@ bwn-firmware-kmod
 drm-kmod
 egl-wayland
 gstreamer1-plugins-neon
+open-vm-tools
 realtek-re-kmod
 utouch-kmod
 xlibre-virtualbox-ose-additions-72
@@ -11,7 +12,9 @@ xlibre-xf86-input-evdev
 xlibre-xf86-input-joystick
 xlibre-xf86-input-keyboard
 xlibre-xf86-input-mouse
+xlibre-xf86-video-qxl
 xlibre-xf86-input-synaptics
 xlibre-xf86-input-vmmouse
 xlibre-xf86-video-scfb
 xlibre-xf86-video-vesa
+xlibre-xf86-video-vmware


### PR DESCRIPTION
Also added some packages for KVM and VMWare

## Summary by Sourcery

Switch the live user’s default shell to zsh and update autologin configuration to use zsh-based startup logic for X sessions.

Enhancements:
- Change the live user’s default shell from fish to zsh across setup scripts.
- Replace fish-based autologin configuration with .zshrc-driven logic to automatically configure graphics and start X on ttyv0.
- Simplify X configuration flow by removing redundant commands and delays during autologin setup.

Chores:
- Touch package lists for common and driver packages, preparing for additional virtualization-related packages.