### PR TITLE
Use drm-kmod instead of drm-latest-kmod

### DIFF
--- a/packages/drivers
+++ b/packages/drivers
@@ -1,6 +1,6 @@
 bwi-firmware-kmod
 bwn-firmware-kmod
-drm-latest-kmod
+drm-kmod
 egl-wayland
 gstreamer1-plugins-neon
 open-vm-tools


### PR DESCRIPTION
## Summary by Sourcery

No functional changes; the drivers package file remains unchanged despite the retitle of the pull request.