### PR TITLE
Exclude nvidia-driver-304 and nvidia-driver-devel from X driver downloads

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -218,8 +218,8 @@ fetch_x_drivers_packages()
   fi
   mkdir ${release}/xdrivers
   yes | pkg -R "${cwd}/pkg/" update -r ${PKG_CONF}
-  echo """$(pkg -R "${cwd}/pkg/" rquery -x -r ${PKG_CONF} '%n %n-%v.pkg' 'xlibre-nvidia-driver|nvidia-kmod|egl-x11' | grep -v libva)""" > ${release}/xdrivers/drivers-list
-  pkg_list="""$(pkg -R "${cwd}/pkg/" rquery -x -r ${PKG_CONF} '%n-%v.pkg' 'xlibre-nvidia-driver|nvidia-kmod|egl-x11' | grep -v libva)"""
+  echo """$(pkg -R "${cwd}/pkg/" rquery -x -r ${PKG_CONF} '%n %n-%v.pkg' 'xlibre-nvidia-driver|nvidia-kmod|egl-x11' | grep -v -E 'libva|304|devel')""" > ${release}/xdrivers/drivers-list
+  pkg_list="""$(pkg -R "${cwd}/pkg/" rquery -x -r ${PKG_CONF} '%n-%v.pkg' 'xlibre-nvidia-driver|nvidia-kmod|egl-x11' | grep -v -E 'libva|304|devel')"""
   for line in $pkg_list ; do
     fetch -o ${release}/xdrivers "${pkg_url}/All/$line"
   done


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent nvidia-driver-304 and nvidia-driver-devel packages from being included in the generated X drivers list and downloaded artifacts.