### PR TITLE
Remove xlibre-xf86-input-synaptics from drivers list

### DIFF
--- a/packages/drivers
+++ b/packages/drivers
@@ -13,7 +13,6 @@ xlibre-xf86-input-joystick
 xlibre-xf86-input-keyboard
 xlibre-xf86-input-mouse
 xlibre-xf86-video-qxl
-xlibre-xf86-input-synaptics
 xlibre-xf86-input-vmmouse
 xlibre-xf86-video-scfb
 xlibre-xf86-video-vesa


### PR DESCRIPTION
Only pre-2010 era laptops need this driver; modern hardware works fine with the default input drivers.

## Summary by Sourcery

Chores:
- Clean up driver package list by dropping obsolete xlibre-xf86-input-synaptics.